### PR TITLE
tools: fix TypeScript lint warnings and remove unused variable

### DIFF
--- a/tools/cargo-toml.d.ts
+++ b/tools/cargo-toml.d.ts
@@ -115,6 +115,7 @@ export interface PackageConfig {
   publish?: boolean | string[];
 
   /** Package metadata */
+  // deno-lint-ignore no-explicit-any
   metadata?: Record<string, any>;
 
   /** Default run target */
@@ -156,6 +157,7 @@ export interface WorkspaceConfig {
   package?: Partial<PackageConfig>;
 
   /** Workspace metadata */
+  // deno-lint-ignore no-explicit-any
   metadata?: Record<string, any>;
 }
 
@@ -399,6 +401,7 @@ export interface BadgeConfig {
   service?: string;
 
   /** Additional badge properties */
+  // deno-lint-ignore no-explicit-any
   [key: string]: any;
 }
 

--- a/tools/publish.ts
+++ b/tools/publish.ts
@@ -1,8 +1,6 @@
 import { parse } from "jsr:@std/toml";
 import { CargoToml } from "./cargo-toml.d.ts";
 
-let defaultTarget: string | undefined;
-
 /**
  * Run tests for the wit_owo Rust project
  * @param features - Array of feature flags to enable (e.g., ['async', 'blocking'])


### PR DESCRIPTION
- Add `deno-lint-ignore no-explicit-any` comments to suppress lint warnings in cargo-toml.d.ts
- Remove unused `defaultTarget` variable from publish.ts
- Improve type definitions and code quality in tools/